### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/altzero/rapidpro.png?label=ready&title=Ready)](https://waffle.io/altzero/rapidpro)
 [![Coverage Status](https://coveralls.io/repos/github/rapidpro/rapidpro/badge.svg?branch=master)](https://coveralls.io/github/rapidpro/rapidpro?branch=master)
 
 # RapidPro


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/altzero/rapidpro

This was requested by a real person (user adamlutz) on waffle.io, we're not trying to spam you.